### PR TITLE
feat: add virtual field 'manager' to User entity

### DIFF
--- a/api-schema.graphql
+++ b/api-schema.graphql
@@ -403,6 +403,7 @@ type User {
   developer: Boolean
   id: String!
   identities: [Identity!]
+  manager: Boolean
   name: String
   profileUrl: String!
   role: UserRole

--- a/libs/api/auth/data-access/src/lib/strategies/api-auth-strategy-jwt.ts
+++ b/libs/api/auth/data-access/src/lib/strategies/api-auth-strategy-jwt.ts
@@ -1,7 +1,7 @@
+import { ApiCoreService } from '@deanslist-platform/api-core-data-access'
 import { Injectable, UnauthorizedException } from '@nestjs/common'
 import { PassportStrategy } from '@nestjs/passport'
 import { UserStatus } from '@prisma/client'
-import { ApiCoreService } from '@deanslist-platform/api-core-data-access'
 import { Request } from 'express-serve-static-core'
 import { Strategy } from 'passport-jwt'
 
@@ -23,7 +23,14 @@ export class ApiAuthStrategyJwt extends PassportStrategy(Strategy) {
     if (!payload.id) {
       throw new UnauthorizedException()
     }
-    const user = await this.core.data.user.findUnique({ where: { id: payload.id } })
+    const user = await this.core.data.user.findUnique({
+      where: { id: payload.id },
+      include: {
+        teams: { select: { id: true } },
+        projectManagers: { select: { id: true } },
+      },
+    })
+
     if (!user) {
       throw new UnauthorizedException()
     }

--- a/libs/api/user/data-access/src/lib/entity/user.entity.ts
+++ b/libs/api/user/data-access/src/lib/entity/user.entity.ts
@@ -24,4 +24,8 @@ export class User {
   username!: string
   @HideField()
   identities?: unknown[] | null
+  @HideField()
+  projectManagers?: unknown[] | null
+  @HideField()
+  teams?: unknown[] | null
 }

--- a/libs/api/user/feature/src/lib/api-user.resolver.ts
+++ b/libs/api/user/feature/src/lib/api-user.resolver.ts
@@ -1,12 +1,17 @@
-import { Parent, ResolveField, Resolver } from '@nestjs/graphql'
 import { Identity } from '@deanslist-platform/api-identity-data-access'
 import { User } from '@deanslist-platform/api-user-data-access'
+import { Parent, ResolveField, Resolver } from '@nestjs/graphql'
 
 @Resolver(() => User)
 export class ApiUserResolver {
   @ResolveField(() => String, { nullable: true })
   avatarUrl(@Parent() user: User) {
     return user.avatarUrl?.length ? user.avatarUrl : null
+  }
+
+  @ResolveField(() => Boolean, { nullable: true })
+  manager(@Parent() user: User) {
+    return !!user.teams?.length || !!user.projectManagers?.length
   }
 
   @ResolveField(() => String)

--- a/libs/sdk/src/generated/graphql-sdk.ts
+++ b/libs/sdk/src/generated/graphql-sdk.ts
@@ -786,6 +786,7 @@ export type User = {
   developer?: Maybe<Scalars['Boolean']['output']>
   id: Scalars['String']['output']
   identities?: Maybe<Array<Identity>>
+  manager?: Maybe<Scalars['Boolean']['output']>
   name?: Maybe<Scalars['String']['output']>
   profileUrl: Scalars['String']['output']
   role?: Maybe<UserRole>
@@ -920,6 +921,7 @@ export type LoginMutation = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -945,6 +947,7 @@ export type RegisterMutation = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -964,6 +967,7 @@ export type MeQuery = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -991,6 +995,7 @@ export type CommentDetailsFragment = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -1036,6 +1041,7 @@ export type UserFindManyCommentQuery = {
         developer?: boolean | null
         id: string
         name?: string | null
+        manager?: boolean | null
         profileUrl: string
         role?: UserRole | null
         status?: UserStatus | null
@@ -1050,6 +1056,7 @@ export type UserFindManyCommentQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -1084,6 +1091,7 @@ export type UserCreateCommentMutation = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -1119,6 +1127,7 @@ export type UserUpdateCommentMutation = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -1171,6 +1180,7 @@ export type AdminFindManyCommentQuery = {
         developer?: boolean | null
         id: string
         name?: string | null
+        manager?: boolean | null
         profileUrl: string
         role?: UserRole | null
         status?: UserStatus | null
@@ -1185,6 +1195,7 @@ export type AdminFindManyCommentQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -1220,6 +1231,7 @@ export type AdminUpdateCommentMutation = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -1570,6 +1582,7 @@ export type AdminFindManyIdentityQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2149,6 +2162,7 @@ export type ReviewDetailsFragment = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -2200,6 +2214,7 @@ export type UserFindManyReviewQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2252,6 +2267,7 @@ export type UserFindUserProjectReviewQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2304,6 +2320,7 @@ export type UserFindOneReviewQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2356,6 +2373,7 @@ export type UserCreateReviewMutation = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2416,6 +2434,7 @@ export type AdminFindManyReviewQuery = {
         developer?: boolean | null
         id: string
         name?: string | null
+        manager?: boolean | null
         profileUrl: string
         role?: UserRole | null
         status?: UserStatus | null
@@ -2479,6 +2498,7 @@ export type AdminFindOneReviewQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2519,6 +2539,7 @@ export type TeamMemberDetailsFragment = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -2547,6 +2568,7 @@ export type UserGetTeamMembersQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2576,6 +2598,7 @@ export type UserGetTeamMemberQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2728,6 +2751,7 @@ export type AdminGetTeamMembersQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2829,6 +2853,7 @@ export type UserDetailsFragment = {
   developer?: boolean | null
   id: string
   name?: string | null
+  manager?: boolean | null
   profileUrl: string
   role?: UserRole | null
   status?: UserStatus | null
@@ -2849,6 +2874,7 @@ export type AdminCreateUserMutation = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -2878,6 +2904,7 @@ export type AdminFindManyUserQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -2923,6 +2950,7 @@ export type AdminFindOneUserQuery = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -2945,6 +2973,7 @@ export type AdminUpdateUserMutation = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -2968,6 +2997,7 @@ export type UserFindManyUserQuery = {
       developer?: boolean | null
       id: string
       name?: string | null
+      manager?: boolean | null
       profileUrl: string
       role?: UserRole | null
       status?: UserStatus | null
@@ -3000,6 +3030,7 @@ export type UserFindOneUserQuery = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -3021,6 +3052,7 @@ export type UserUpdateUserMutation = {
     developer?: boolean | null
     id: string
     name?: string | null
+    manager?: boolean | null
     profileUrl: string
     role?: UserRole | null
     status?: UserStatus | null
@@ -3036,6 +3068,7 @@ export const UserDetailsFragmentDoc = gql`
     developer
     id
     name
+    manager
     profileUrl
     role
     status

--- a/libs/sdk/src/graphql/feature-user.graphql
+++ b/libs/sdk/src/graphql/feature-user.graphql
@@ -4,6 +4,7 @@ fragment UserDetails on User {
   developer
   id
   name
+  manager
   profileUrl
   role
   status

--- a/libs/web/core/feature/src/lib/shell-layout.tsx
+++ b/libs/web/core/feature/src/lib/shell-layout.tsx
@@ -1,16 +1,25 @@
 import { useAuth } from '@deanslist-platform/web-auth-data-access'
-import { CoreUiHeader, CoreUiHeaderProfile, CoreUiLayout } from '@deanslist-platform/web-core-ui'
+import { CoreUiHeader, CoreUiHeaderLink, CoreUiHeaderProfile, CoreUiLayout } from '@deanslist-platform/web-core-ui'
 import { ActionIcon, Group } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import { UiLoader } from '@pubkey-ui/core'
 import { IconBrandDiscord, IconShield } from '@tabler/icons-react'
-import { ReactNode, Suspense } from 'react'
+import { ReactNode, Suspense, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 
 export function ShellLayout({ children }: { children: ReactNode }) {
   const { user, isAdmin, logout } = useAuth()
   const [opened, { toggle }] = useDisclosure(false)
   const profile = <CoreUiHeaderProfile user={user} logout={logout} />
+  const links: CoreUiHeaderLink[] = useMemo(
+    () =>
+      [
+        { link: '/projects', label: 'Projects' },
+        user?.manager ? { link: '/teams', label: 'Teams' } : null,
+        { link: `${user?.profileUrl}`, label: 'Profile' },
+      ].filter(Boolean) as CoreUiHeaderLink[],
+    [user],
+  )
 
   return (
     <CoreUiLayout
@@ -18,11 +27,7 @@ export function ShellLayout({ children }: { children: ReactNode }) {
         <CoreUiHeader
           opened={opened}
           toggle={toggle}
-          links={[
-            { link: '/projects', label: 'Projects' },
-            { link: '/teams', label: 'Teams' },
-            { link: `${user?.profileUrl}`, label: 'Profile' },
-          ]}
+          links={links}
           profile={
             isAdmin ? (
               <Group gap="xs">


### PR DESCRIPTION
We use the [`ResolveField`](https://docs.nestjs.com/graphql/resolvers) decorator to create a dynamic field called `manager`. It's set to true if a user has either teams they are member of, or if they are assigned as a manager to a project.

We can use this flag to dynamically render the navigation for managers.